### PR TITLE
Bumbed version to 7.7.1.  Also

### DIFF
--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:stretch-slim as base
 LABEL maintainer "Dave Curylo <dave@curylo.org>, Michael Hendricks <michael@ndrix.org>"
 
 RUN apt-get update && \
@@ -19,6 +19,8 @@ RUN apt-get update && \
     libmariadbclient18 && \
     rm -rf /var/lib/apt/lists/*
 
+FROM base as build
+
 ENV SWIPL_VER 7.7.1
 ENV SWIPL_CHECKSUM fda2c8b6b606ff199ea8a6f019008aa8272b7c349cb9312ccd5944153509503a
 ENV BUILD_DEPS make gcc g++ wget libarchive-dev libgmp-dev libossp-uuid-dev libpcre3-dev \
@@ -27,8 +29,8 @@ ENV BUILD_DEPS make gcc g++ wget libarchive-dev libgmp-dev libossp-uuid-dev libp
 
 ENV SPACE_SHA1 cd6fefa63317a7a6effb61a1c5aee634ebe2ca05
 
-RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
-    mkdir /tmp/src && \
+RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS}
+RUN mkdir /tmp/src && \
     cd /tmp/src && \
     wget http://www.swi-prolog.org/download/devel/src/swipl-${SWIPL_VER}.tar.gz && \
     echo "${SWIPL_CHECKSUM}  swipl-${SWIPL_VER}.tar.gz" >> swipl-${SWIPL_VER}.tar.gz-CHECKSUM && \
@@ -41,15 +43,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} &
     sed -i 's/# *\(.*--disable-libdirversion\)/\1/' build && \
     chmod u+x build && ./build && \
     rm -r /tmp/src && \
-    cd /usr/bin && ln -s /swipl/bin/swipl swipl && \
-    mkdir /swipl/lib/swipl/pack && \
+    cd /usr/bin && ln -s /swipl/bin/swipl swipl
+
+RUN mkdir /swipl/lib/swipl/pack && \
     cd /swipl/lib/swipl/pack && \
     git clone https://github.com/JanWielemaker/space.git && \
     (cd space && git checkout -q ${SPACE_SHA1}) && \
     (cd space && ln -s configure.ac configure.in) && \
-    swipl -g 'pack_rebuild(space)' -t halt && \
-    apt-get purge -y --auto-remove ${BUILD_DEPS} && \
-    rm -rf /var/lib/apt/lists/*
+    swipl -g 'pack_rebuild(space)' -t halt
+
+FROM base
+
+COPY --from=build /swipl /swipl
+RUN cd /usr/bin && ln -s /swipl/bin/swipl* .
 
 ENV LANG C.UTF-8
 CMD ["swipl"]

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -6,15 +6,11 @@ RUN apt-get update && \
     libarchive13 \
     libgmp10 \
     libossp-uuid16 \
-    libssl1.1 \
-    ca-certificates \
+    libssl1.1 ca-certificates \
     libdb5.3 \
     libpcre3 \
     libedit2 \
-    unixodbc \
-    odbc-postgresql \
-    tdsodbc \
-    libmariadbclient18 \
+    unixodbc odbc-postgresql tdsodbc libmariadbclient18 \
     libgeos-c1v5 libspatialindex4v5 \
     libsqlite3-0 \
     librocksdb4.5 \

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -11,25 +11,37 @@ RUN apt-get update && \
     libdb5.3 \
     libpcre3 \
     libedit2 \
-    libgeos-c1v5 \
-    libspatialindex4v5 \
     unixodbc \
     odbc-postgresql \
     tdsodbc \
-    libmariadbclient18 && \
+    libmariadbclient18 \
+    libgeos-c1v5 libspatialindex4v5 \
+    libsqlite3-0 \
+    librocksdb4.5 \
+    libserd-0-0 libraptor2-0 && \
     rm -rf /var/lib/apt/lists/*
 
 FROM base as build
 
-ENV SWIPL_VER 7.7.1
-ENV SWIPL_CHECKSUM fda2c8b6b606ff199ea8a6f019008aa8272b7c349cb9312ccd5944153509503a
-ENV BUILD_DEPS make gcc g++ wget libarchive-dev libgmp-dev libossp-uuid-dev libpcre3-dev \
-	       libreadline-dev libedit-dev libssl-dev zlib1g-dev libdb-dev libgeos++-dev \
-	       libspatialindex-dev unixodbc-dev git autoconf
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    make gcc g++ wget git autoconf \
+    libarchive-dev libgmp-dev libossp-uuid-dev libpcre3-dev \
+    libreadline-dev libedit-dev libssl-dev zlib1g-dev libdb-dev \
+    unixodbc-dev \
+    libgeos++-dev libspatialindex-dev \
+    libsqlite3-dev \
+    librocksdb-dev \
+    libserd-dev libraptor2-dev
 
-ENV SPACE_SHA1 cd6fefa63317a7a6effb61a1c5aee634ebe2ca05
+ENV SWIPL_VER=7.7.1 \
+    SWIPL_CHECKSUM=fda2c8b6b606ff199ea8a6f019008aa8272b7c349cb9312ccd5944153509503a \
+    SPACE_SHA1=cd6fefa63317a7a6effb61a1c5aee634ebe2ca05 \
+    PROSQLITE_SHA1=a1d915d07933ece27ea5fd68f07c83d10583e7a0 \
+    ROCKSDB_SHA1=29eaee6fcdb6dce690ed187ef68b80ee94739412 \
+    HDT_SHA1=e0a0eff87fc3318434cb493690c570e1255ed30e \
+    RSERVE_CLIENT_SHA1=72838bbfa3976a83d19fb38bdae04378e30f4b0d
 
-RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS}
 RUN mkdir /tmp/src && \
     cd /tmp/src && \
     wget http://www.swi-prolog.org/download/devel/src/swipl-${SWIPL_VER}.tar.gz && \
@@ -53,28 +65,31 @@ RUN mkdir /swipl/lib/swipl/pack && \
     (cd space && ln -s configure.ac configure.in) && \
     swipl -g 'pack_rebuild(space)' -t halt
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libsqlite3-dev librocksdb-dev
-
 RUN cd /swipl/lib/swipl/pack && \
     git clone https://github.com/nicos-angelopoulos/prosqlite.git && \
-    (cd prosqlite && git checkout -q a1d915d07933ece27ea5fd68f07c83d10583e7a0) && \
+    (cd prosqlite && git checkout -q ${PROSQLITE_SHA1}) && \
     rm -rf prosqlite/lib prosqlite/.git && \
     swipl -g 'pack_rebuild(prosqlite)' -t halt
 
 RUN cd /swipl/lib/swipl/pack && \
     git clone https://github.com/JanWielemaker/rocksdb.git && \
-    (cd rocksdb && git checkout -q 29eaee6fcdb6dce690ed187ef68b80ee94739412) && \
+    (cd rocksdb && git checkout -q ${ROCKSDB_SHA1}) && \
     rm -rf rocksdb/.git && \
     swipl -g 'pack_rebuild(rocksdb)' -t halt
 
-FROM base
+RUN cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/hdt.git && \
+    (cd hdt && git checkout -q ${HDT_SHA1}) && \
+    swipl -g 'pack_rebuild(hdt)' -t halt && \
+    rm -rf hdt/hdt-cpp hdt/.git hdt/c/*.o
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libsqlite3-0 \
-    librocksdb4.5 && \
-    rm -rf /var/lib/apt/lists/*
+RUN cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/rserve_client.git && \
+    (cd rserve_client && git checkout -q ${RSERVE_CLIENT_SHA1}) && \
+    swipl -g 'pack_rebuild(rserve_client)' -t halt && \
+    rm -rf rserve_client/Rserve rserve_client/.git rserve_client/cc/*.o
+
+FROM base
 
 COPY --from=build /swipl /swipl
 RUN cd /usr/bin && ln -s /swipl/bin/swipl* .

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     libgmp10 \
     libossp-uuid16 \
     libssl1.1 \
+    ca-certificates \
     libdb5.3 \
     libpcre3 \
     libedit2 \
@@ -22,7 +23,7 @@ ENV SWIPL_VER 7.7.1
 ENV SWIPL_CHECKSUM fda2c8b6b606ff199ea8a6f019008aa8272b7c349cb9312ccd5944153509503a
 ENV BUILD_DEPS make gcc g++ wget libarchive-dev libgmp-dev libossp-uuid-dev libpcre3-dev \
 	       libreadline-dev libedit-dev libssl-dev zlib1g-dev libdb-dev libgeos++-dev \
-	       libspatialindex-dev unixodbc-dev git ca-certificates autoconf
+	       libspatialindex-dev unixodbc-dev git autoconf
 
 ENV SPACE_SHA1 cd6fefa63317a7a6effb61a1c5aee634ebe2ca05
 

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -1,0 +1,54 @@
+FROM debian:stretch-slim
+LABEL maintainer "Dave Curylo <dave@curylo.org>, Michael Hendricks <michael@ndrix.org>"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libarchive13 \
+    libgmp10 \
+    libossp-uuid16 \
+    libssl1.1 \
+    libdb5.3 \
+    libpcre3 \
+    libedit2 \
+    libgeos-c1v5 \
+    libspatialindex4v5 \
+    unixodbc \
+    odbc-postgresql \
+    tdsodbc \
+    libmariadbclient18 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV SWIPL_VER 7.7.1
+ENV SWIPL_CHECKSUM fda2c8b6b606ff199ea8a6f019008aa8272b7c349cb9312ccd5944153509503a
+ENV BUILD_DEPS make gcc g++ wget libarchive-dev libgmp-dev libossp-uuid-dev libpcre3-dev \
+	       libreadline-dev libedit-dev libssl-dev zlib1g-dev libdb-dev libgeos++-dev \
+	       libspatialindex-dev unixodbc-dev git ca-certificates autoconf
+
+ENV SPACE_SHA1 cd6fefa63317a7a6effb61a1c5aee634ebe2ca05
+
+RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
+    mkdir /tmp/src && \
+    cd /tmp/src && \
+    wget http://www.swi-prolog.org/download/devel/src/swipl-${SWIPL_VER}.tar.gz && \
+    echo "${SWIPL_CHECKSUM}  swipl-${SWIPL_VER}.tar.gz" >> swipl-${SWIPL_VER}.tar.gz-CHECKSUM && \
+    sha256sum -c swipl-${SWIPL_VER}.tar.gz-CHECKSUM && \
+    tar -xzf swipl-${SWIPL_VER}.tar.gz && \
+    cd swipl-${SWIPL_VER} && \
+    cp build.templ build && \
+    sed -i '/PREFIX=$HOME/c\PREFIX=/swipl' build && \
+    sed -i '/# export DISABLE_PKGS/c\export DISABLE_PKGS="jpl xpce"' build && \
+    sed -i 's/# *\(.*--disable-libdirversion\)/\1/' build && \
+    chmod u+x build && ./build && \
+    rm -r /tmp/src && \
+    cd /usr/bin && ln -s /swipl/bin/swipl swipl && \
+    mkdir /swipl/lib/swipl/pack && \
+    cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/space.git && \
+    (cd space && git checkout -q ${SPACE_SHA1}) && \
+    (cd space && ln -s configure.ac configure.in) && \
+    swipl -g 'pack_rebuild(space)' -t halt && \
+    apt-get purge -y --auto-remove ${BUILD_DEPS} && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LANG C.UTF-8
+CMD ["swipl"]

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -49,10 +49,32 @@ RUN mkdir /swipl/lib/swipl/pack && \
     cd /swipl/lib/swipl/pack && \
     git clone https://github.com/JanWielemaker/space.git && \
     (cd space && git checkout -q ${SPACE_SHA1}) && \
+    rm -rf space/.git && \
     (cd space && ln -s configure.ac configure.in) && \
     swipl -g 'pack_rebuild(space)' -t halt
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsqlite3-dev librocksdb-dev
+
+RUN cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/nicos-angelopoulos/prosqlite.git && \
+    (cd prosqlite && git checkout -q a1d915d07933ece27ea5fd68f07c83d10583e7a0) && \
+    rm -rf prosqlite/lib prosqlite/.git && \
+    swipl -g 'pack_rebuild(prosqlite)' -t halt
+
+RUN cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/rocksdb.git && \
+    (cd rocksdb && git checkout -q 29eaee6fcdb6dce690ed187ef68b80ee94739412) && \
+    rm -rf rocksdb/.git && \
+    swipl -g 'pack_rebuild(rocksdb)' -t halt
+
 FROM base
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libsqlite3-0 \
+    librocksdb4.5 && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /swipl /swipl
 RUN cd /usr/bin && ln -s /swipl/bin/swipl* .


### PR DESCRIPTION
  - Move constants to docker environment vars
  - Disables libdir versions, so we get /swipl/lib/swipl without  versions
  - Install space from the addon registry.  space is not part of the tarball.