### PR TITLE
WIP: Bump to 7.7.1, include space, prosqlite, rocksdb, hdt, rserve addins

### DIFF
--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -51,30 +51,38 @@ RUN SWIPL_VER=7.7.1 \
     rm -rf space/.git && \
     (cd space && ln -s configure.ac configure.in) && \
     swipl -g 'pack_rebuild(space)' -t halt && \
+    cd space && \
+    find -maxdepth 1 ! -name . ! -name lib ! -name prolog ! -name pack.pl -exec rm -rf {} \; && \
     # prosqlite addin
     cd /swipl/lib/swipl/pack && \
     git clone https://github.com/nicos-angelopoulos/prosqlite.git && \
     (cd prosqlite && git checkout -q ${PROSQLITE_SHA1}) && \
     rm -rf prosqlite/lib prosqlite/.git && \
     swipl -g 'pack_rebuild(prosqlite)' -t halt && \
+    cd prosqlite && \
+    find -maxdepth 1 ! -name . ! -name lib ! -name prolog ! -name pack.pl -exec rm -rf {} \; && \
     # rocksdb addin
     cd /swipl/lib/swipl/pack && \
     git clone https://github.com/JanWielemaker/rocksdb.git && \
     (cd rocksdb && git checkout -q ${ROCKSDB_SHA1}) && \
     rm -rf rocksdb/.git && \
     swipl -g 'pack_rebuild(rocksdb)' -t halt && \
+    cd rocksdb && \
+    find -maxdepth 1 ! -name . ! -name lib ! -name prolog ! -name pack.pl -exec rm -rf {} \; && \
     # hdt addin
     cd /swipl/lib/swipl/pack && \
     git clone https://github.com/JanWielemaker/hdt.git && \
     (cd hdt && git checkout -q ${HDT_SHA1}) && \
     swipl -g 'pack_rebuild(hdt)' -t halt && \
-    rm -rf hdt/hdt-cpp hdt/.git hdt/c/*.o && \
+    cd hdt && \
+    find -maxdepth 1 ! -name . ! -name lib ! -name prolog ! -name pack.pl -exec rm -rf {} \; && \
     # rserve addin
     cd /swipl/lib/swipl/pack && \
     git clone https://github.com/JanWielemaker/rserve_client.git && \
     (cd rserve_client && git checkout -q ${RSERVE_CLIENT_SHA1}) && \
     swipl -g 'pack_rebuild(rserve_client)' -t halt && \
-    rm -rf rserve_client/Rserve rserve_client/.git rserve_client/cc/*.o && \
+    cd rserve_client && \
+    find -maxdepth 1 ! -name . ! -name lib ! -name prolog ! -name pack.pl -exec rm -rf {} \; && \
     # finally clean up apt
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove $BUILD_DEPS && \

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -40,7 +40,7 @@ RUN SWIPL_VER=7.7.1 \
     cp build.templ build && \
     sed -i '/PREFIX=$HOME/c\PREFIX=/swipl' build && \
     sed -i '/# export DISABLE_PKGS/c\export DISABLE_PKGS="jpl xpce"' build && \
-    sed -i 's/# *\(.*--disable-libdirversion\)/\1/' build && \
+    sed -i 's/# *\(EXTRA.*--disable-libdirversion\)/\1/' build && \
     chmod u+x build && ./build && \
     cd /usr/bin && rm -rf /tmp/src && ln -s /swipl/bin/swipl swipl && \
     # space addin

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -1,0 +1,84 @@
+FROM debian:stretch-slim
+LABEL maintainer "Dave Curylo <dave@curylo.org>, Michael Hendricks <michael@ndrix.org>"
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libarchive13 \
+    libgmp10 \
+    libossp-uuid16 \
+    libssl1.1 \
+    ca-certificates \
+    libdb5.3 \
+    libpcre3 \
+    libedit2 \
+    libgeos-c1v5 \
+    libspatialindex4v5 \
+    unixodbc \
+    odbc-postgresql \
+    tdsodbc \
+    libmariadbclient18 \
+    libsqlite3-0 \
+    librocksdb4.5 \
+    libserd-0-0 \
+    libraptor2-0 && \
+    rm -rf /var/lib/apt/lists/*
+RUN SWIPL_VER=7.7.1 \
+    SWIPL_CHECKSUM=fda2c8b6b606ff199ea8a6f019008aa8272b7c349cb9312ccd5944153509503a \
+    SPACE_SHA1=cd6fefa63317a7a6effb61a1c5aee634ebe2ca05 \
+    PROSQLITE_SHA1=a1d915d07933ece27ea5fd68f07c83d10583e7a0 \
+    ROCKSDB_SHA1=29eaee6fcdb6dce690ed187ef68b80ee94739412 \
+    HDT_SHA1=e0a0eff87fc3318434cb493690c570e1255ed30e \
+    RSERVE_CLIENT_SHA1=72838bbfa3976a83d19fb38bdae04378e30f4b0d && \
+    BUILD_DEPS='make gcc g++ wget git autoconf libarchive-dev libgmp-dev libossp-uuid-dev libpcre3-dev libreadline-dev libedit-dev libssl-dev zlib1g-dev libdb-dev unixodbc-dev libsqlite3-dev librocksdb-dev libserd-dev libraptor2-dev libgeos++-dev libspatialindex-dev' && \
+    apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS && \
+    mkdir /tmp/src && \
+    cd /tmp/src && \
+    wget http://www.swi-prolog.org/download/devel/src/swipl-$SWIPL_VER.tar.gz && \
+    echo "$SWIPL_CHECKSUM  swipl-$SWIPL_VER.tar.gz" >> swipl-$SWIPL_VER.tar.gz-CHECKSUM && \
+    sha256sum -c swipl-$SWIPL_VER.tar.gz-CHECKSUM && \
+    tar -xzf swipl-$SWIPL_VER.tar.gz && \
+    cd swipl-$SWIPL_VER && \
+    cp build.templ build && \
+    sed -i '/PREFIX=$HOME/c\PREFIX=/swipl' build && \
+    sed -i '/# export DISABLE_PKGS/c\export DISABLE_PKGS="jpl xpce"' build && \
+    sed -i '/# export EXTRA_PKGS/c\export EXTRA_PKGS="db space"' build && \
+    chmod u+x build && ./build && \
+    cd /usr/bin && rm -rf /tmp/src && ln -s /swipl/bin/swipl swipl && \
+    # space addin
+    mkdir -p /swipl/lib/swipl/pack && \
+    cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/space.git && \
+    (cd space && git checkout -q ${SPACE_SHA1}) && \
+    rm -rf space/.git && \
+    (cd space && ln -s configure.ac configure.in) && \
+    swipl -g 'pack_rebuild(space)' -t halt && \
+    # prosqlite addin
+    cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/nicos-angelopoulos/prosqlite.git && \
+    (cd prosqlite && git checkout -q ${PROSQLITE_SHA1}) && \
+    rm -rf prosqlite/lib prosqlite/.git && \
+    swipl -g 'pack_rebuild(prosqlite)' -t halt && \
+    # rocksdb addin
+    cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/rocksdb.git && \
+    (cd rocksdb && git checkout -q ${ROCKSDB_SHA1}) && \
+    rm -rf rocksdb/.git && \
+    swipl -g 'pack_rebuild(rocksdb)' -t halt && \
+    # hdt addin
+    cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/hdt.git && \
+    (cd hdt && git checkout -q ${HDT_SHA1}) && \
+    swipl -g 'pack_rebuild(hdt)' -t halt && \
+    rm -rf hdt/hdt-cpp hdt/.git hdt/c/*.o && \
+    # rserve addin
+    cd /swipl/lib/swipl/pack && \
+    git clone https://github.com/JanWielemaker/rserve_client.git && \
+    (cd rserve_client && git checkout -q ${RSERVE_CLIENT_SHA1}) && \
+    swipl -g 'pack_rebuild(rserve_client)' -t halt && \
+    rm -rf rserve_client/Rserve rserve_client/.git rserve_client/cc/*.o && \
+    # finally clean up apt
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get purge -y --auto-remove $BUILD_DEPS && \
+    rm /usr/bin/swipl && cd /usr/bin && ln -s /swipl/bin/swipl* .
+
+ENV LANG C.UTF-8
+CMD ["swipl"]

--- a/7.7.1/stretch/Dockerfile
+++ b/7.7.1/stretch/Dockerfile
@@ -40,7 +40,7 @@ RUN SWIPL_VER=7.7.1 \
     cp build.templ build && \
     sed -i '/PREFIX=$HOME/c\PREFIX=/swipl' build && \
     sed -i '/# export DISABLE_PKGS/c\export DISABLE_PKGS="jpl xpce"' build && \
-    sed -i '/# export EXTRA_PKGS/c\export EXTRA_PKGS="db space"' build && \
+    sed -i 's/# *\(.*--disable-libdirversion\)/\1/' build && \
     chmod u+x build && ./build && \
     cd /usr/bin && rm -rf /tmp/src && ln -s /swipl/bin/swipl swipl && \
     # space addin


### PR DESCRIPTION
@JanWielemaker I combined the multi-stage build to a single stage, but it seems I've overlooked something, as `pack_rebuild(space)` is failing.  I really could use another set of eyes to review it, please.

```
/swipl/bin/swipl -f none -g check_installation -t halt
% Checking your SWI-Prolog kit for common issues ...
... (snipped all the 'ok' lines) ...
Warning: Could not find swipl on $PATH. 
Warning: You may wish to add '/swipl/bin' to $PATH. 
Warning: Found 2 issues.
make[1]: Leaving directory '/tmp/src/swipl-7.7.1/src'
No errors during package build
Cloning into 'space'...
ERROR: -g pack_rebuild(space): pack `space' does not exist
```